### PR TITLE
Improve mobile layout for register form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2419,21 +2419,20 @@
 
                 <!-- Vista Registrar Inspección -->
                 <div id="registrar-view" class="view-container hidden space-y-6 animate-fadeIn">
-                    <div class="flex justify-between items-center">
-                        <div>
+                    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+                        <div class="flex-1">
                             <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Registrar Inspección</h1>
                             <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Ingrese los datos de la inspección
                                 del extintor</p>
                         </div>
-                        <button id="historial-bus-btn" class="btn btn-light" disabled>
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" viewBox="0 0 20 20"
-                                fill="currentColor">
-                                <path fill-rule="evenodd"
-                                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z"
-                                    clip-rule="evenodd" />
-                            </svg>
-                            Ver historial del bus
-                        </button><br>
+                        <div class="flex flex-wrap items-center gap-2 mt-4 sm:mt-0">
+                            <button id="historial-bus-btn" class="btn btn-light w-full sm:w-auto" disabled>
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd" />
+                                </svg>
+                                Ver historial del bus
+                            </button>
+                        </div>
                     </div>
 
                     <div class="card">
@@ -2500,7 +2499,7 @@
 
                                         <!-- Alerta de bus ya revisado -->
                                         <div id="bus-already-checked"
-                                            class="hidden rounded-md bg-blue-50 dark:bg-blue-900/30 p-4 border border-blue-200 dark:border-blue-800 mt-4">
+                                            class="hidden w-full max-w-full rounded-md bg-blue-50 dark:bg-blue-900/30 p-4 border border-blue-200 dark:border-blue-800 mt-4">
                                             <div class="flex items-start">
                                                 <div class="flex-shrink-0">
                                                     <svg class="h-5 w-5 text-blue-600 dark:text-blue-400"

--- a/pendientes-flota.js
+++ b/pendientes-flota.js
@@ -53,7 +53,7 @@
         if (historialBtn && historialBtn.parentNode) {
             const pendientesBtn = document.createElement('button');
             pendientesBtn.id = 'pendientes-flota-btn';
-            pendientesBtn.className = 'btn bg-indigo-500 hover:bg-indigo-600 text-white ml-2 flex items-center justify-center px-4 py-2 rounded-md cursor-pointer';
+            pendientesBtn.className = 'btn bg-indigo-500 hover:bg-indigo-600 text-white flex items-center justify-center px-4 py-2 rounded-md cursor-pointer w-full sm:w-auto';
             pendientesBtn.innerHTML = `
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
@@ -78,7 +78,7 @@
                     // Crear botón
                     const pendientesBtn = document.createElement('button');
                     pendientesBtn.id = 'pendientes-flota-btn';
-                    pendientesBtn.className = 'btn bg-indigo-500 hover:bg-indigo-600 text-white flex items-center justify-center px-4 py-2 rounded-md cursor-pointer';
+                    pendientesBtn.className = 'btn bg-indigo-500 hover:bg-indigo-600 text-white flex items-center justify-center px-4 py-2 rounded-md cursor-pointer w-full sm:w-auto';
                     pendientesBtn.innerHTML = `
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1 inline" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />


### PR DESCRIPTION
## Summary
- make inspection view header responsive and group action buttons
- prevent bus reviewed alert from overflowing on small screens
- ensure pending fleet button adapts to mobile width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc25bfbe0832d959bd2ed835ebcef