### PR TITLE
feat: modal flotante para bus inspeccionado recientemente

### DIFF
--- a/index.html
+++ b/index.html
@@ -2497,40 +2497,6 @@
                                                 class="mt-1 text-xs text-red-600 dark:text-red-400 h-4"></div>
                                         </div>
 
-                                        <!-- Alerta de bus ya revisado -->
-                                        <div id="bus-already-checked"
-                                            class="hidden w-full max-w-full rounded-md bg-blue-50 dark:bg-blue-900/30 p-4 border border-blue-200 dark:border-blue-800 mt-4">
-                                            <div class="flex items-start">
-                                                <div class="flex-shrink-0">
-                                                    <svg class="h-5 w-5 text-blue-600 dark:text-blue-400"
-                                                        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
-                                                        fill="currentColor" aria-hidden="true">
-                                                        <path fill-rule="evenodd"
-                                                            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                                                            clip-rule="evenodd" />
-                                                    </svg>
-                                                </div>
-                                                <div class="ml-3 flex-1">
-                                                    <h3 class="text-sm font-medium text-blue-800 dark:text-blue-300">Bus
-                                                        ya inspeccionado recientemente</h3>
-                                                    <div class="mt-2 text-sm text-blue-700 dark:text-blue-200">
-                                                        <p>Este bus ya fue inspeccionado el <span
-                                                                id="last-inspection-date"
-                                                                class="font-semibold">DD/MM/AAAA</span>.</p>
-                                                    </div>
-                                                    <div class="mt-3 flex space-x-4">
-                                                        <button type="button" id="use-previous-data"
-                                                            class="btn btn-sm btn-light">
-                                                            Usar datos anteriores
-                                                        </button>
-                                                        <button type="button" id="create-new-inspection"
-                                                            class="btn btn-sm btn-primary">
-                                                            Crear nueva inspección
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
                                     </fieldset>
                                 </div>
 
@@ -3701,6 +3667,27 @@
             </div>
         </div>
 
+        <!-- Modal flotante para bus inspeccionado recientemente -->
+        <div id="bus-already-checked" class="fixed inset-0 flex items-center justify-center bg-black/50 z-50 hidden">
+            <div class="relative bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 rounded-md p-6 max-w-md w-full">
+                <button id="close-bus-checked" class="absolute top-2 right-2 text-blue-700 dark:text-blue-300">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+                <h3 class="text-sm font-medium text-blue-800 dark:text-blue-300">Bus ya inspeccionado recientemente</h3>
+                <p class="mt-2 text-sm text-blue-700 dark:text-blue-200">Este bus ya fue inspeccionado el <span id="last-inspection-date" class="font-semibold">DD/MM/AAAA</span>.</p>
+                <div class="mt-4 flex space-x-4 justify-end">
+                    <button type="button" id="use-previous-data" class="btn btn-sm btn-light">
+                        Usar datos anteriores
+                    </button>
+                    <button type="button" id="create-new-inspection" class="btn btn-sm btn-primary">
+                        Crear nueva inspección
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <!-- Contenedor de notificaciones flotantes -->
         <div id="notification-container" class="fixed bottom-5 right-5 z-50 space-y-3"></div>
 
@@ -3785,6 +3772,7 @@
                 lastInspectionDate: null,
                 usePreviousDataBtn: null,
                 createNewInspectionBtn: null,
+                closeBusCheckedBtn: null,
                 historialBusBtn: null,
                 extintorEstadoRadios: null,
                 extintorDetailsContainer: null,
@@ -8243,6 +8231,7 @@
                 DOM.lastInspectionDate = document.getElementById('last-inspection-date');
                 DOM.usePreviousDataBtn = document.getElementById('use-previous-data');
                 DOM.createNewInspectionBtn = document.getElementById('create-new-inspection');
+                DOM.closeBusCheckedBtn = document.getElementById('close-bus-checked');
                 DOM.historialBusBtn = document.getElementById('historial-bus-btn');
                 DOM.extintorEstadoRadios = document.querySelectorAll('input[name="extintor_estado"]');
                 DOM.extintorDetailsContainer = document.getElementById('extintor-details-container');
@@ -8527,6 +8516,14 @@
 
                 if (DOM.usePreviousDataBtn) {
                     DOM.usePreviousDataBtn.addEventListener('click', fillFormWithPreviousData);
+                }
+
+                if (DOM.closeBusCheckedBtn) {
+                    DOM.closeBusCheckedBtn.addEventListener('click', () => {
+                        if (DOM.busAlreadyChecked) {
+                            DOM.busAlreadyChecked.classList.add('hidden');
+                        }
+                    });
                 }
 
                 // Estado extintor (tiene/no tiene)


### PR DESCRIPTION
## Summary
- Mover alerta de bus inspeccionado recientemente a un modal centrado y flotante fuera del formulario
- Añadir botón en forma de "X" para cerrar la alerta
- Conectar el botón de cierre a un listener que oculta el modal

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abc42be0c8832dad2c4d639ed562ea